### PR TITLE
Remove dead code: unused functions from converters

### DIFF
--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -3923,54 +3923,6 @@ class DocumentConverter:
             key = f"{resource_type}/{resource_id}"
             self._author_metadata[key] = authors
 
-    def _store_informant_metadata(
-        self,
-        resource_type: str,
-        resource_id: str,
-        ccda_element,
-        concern_act=None,
-    ):
-        """Store informant metadata for later resource generation.
-
-        Args:
-            resource_type: FHIR resource type (e.g., "Condition", "AllergyIntolerance")
-            resource_id: FHIR resource ID
-            ccda_element: The C-CDA element containing informant information
-            concern_act: Optional concern act (for combined informant extraction)
-        """
-        from ccda_to_fhir.ccda.models.act import Act
-        from ccda_to_fhir.ccda.models.encounter import Encounter as CCDAEncounter
-        from ccda_to_fhir.ccda.models.observation import Observation
-        from ccda_to_fhir.ccda.models.organizer import Organizer
-        from ccda_to_fhir.ccda.models.procedure import Procedure
-        from ccda_to_fhir.ccda.models.substance_administration import SubstanceAdministration
-
-        informants = []
-
-        if concern_act:
-            # Extract from both concern act and entry element
-            informants = self.informant_extractor.extract_combined(concern_act, ccda_element)
-        else:
-            # Extract based on element type
-            if isinstance(ccda_element, Observation):
-                informants = self.informant_extractor.extract_from_observation(ccda_element)
-            elif isinstance(ccda_element, SubstanceAdministration):
-                informants = self.informant_extractor.extract_from_substance_administration(
-                    ccda_element
-                )
-            elif isinstance(ccda_element, Procedure):
-                informants = self.informant_extractor.extract_from_procedure(ccda_element)
-            elif isinstance(ccda_element, CCDAEncounter):
-                informants = self.informant_extractor.extract_from_encounter(ccda_element)
-            elif isinstance(ccda_element, Organizer):
-                informants = self.informant_extractor.extract_from_organizer(ccda_element)
-            elif isinstance(ccda_element, Act):
-                informants = self.informant_extractor.extract_from_concern_act(ccda_element)
-
-        if informants:
-            key = f"{resource_type}/{resource_id}"
-            self._informant_metadata[key] = informants
-
     def _generate_informant_resources(
         self
     ) -> tuple[list[FHIRResourceDict], list[FHIRResourceDict]]:

--- a/ccda_to_fhir/converters/immunization.py
+++ b/ccda_to_fhir/converters/immunization.py
@@ -1012,31 +1012,6 @@ class ImmunizationConverter(BaseConverter[SubstanceAdministration]):
         # Immunization notes only come from comment activities, not from text element
         return self.extract_notes_from_element(substance_admin, include_text=False)
 
-    def _format_name_for_display(self, name) -> str | None:
-        """Format a name for display.
-
-        Args:
-            name: The name element (PN)
-
-        Returns:
-            Formatted name string or None
-        """
-        parts = []
-
-        # Extract given names
-        if hasattr(name, 'given') and name.given:
-            for given in name.given:
-                parts.append(str(given))
-
-        # Extract family name
-        if hasattr(name, 'family') and name.family:
-            if isinstance(name.family, list):
-                parts.extend(str(f) for f in name.family)
-            else:
-                parts.append(str(name.family))
-
-        return " ".join(parts) if parts else None
-
     def _convert_code_to_codeable_concept(self, code_elem: CD | CE) -> JSONObject | None:
         """Convert a C-CDA CD/CE code element to a FHIR CodeableConcept.
 

--- a/ccda_to_fhir/converters/note_activity.py
+++ b/ccda_to_fhir/converters/note_activity.py
@@ -494,63 +494,6 @@ class NoteActivityConverter(BaseConverter[Act]):
 
         return extract_text_by_id(section.text, ref_id)
 
-    def _extract_narrative_by_id(self, narrative, target_id: str) -> str | None:
-        """Extract text content from CDA narrative by ID.
-
-        Args:
-            narrative: StrucDocText narrative object
-            target_id: ID to search for
-
-        Returns:
-            Text content as string or None
-        """
-        # Try to convert narrative to XML and search
-        try:
-            # If narrative has an XML representation, search it
-            if hasattr(narrative, "__dict__"):
-                # Search through narrative elements
-                for attr_name, attr_value in vars(narrative).items():
-                    if isinstance(attr_value, list):
-                        for item in attr_value:
-                            text = self._search_element_for_id(item, target_id)
-                            if text:
-                                return text
-            return None
-        except Exception:
-            return None
-
-    def _search_element_for_id(self, element, target_id: str) -> str | None:
-        """Recursively search an element for matching ID.
-
-        Args:
-            element: Element to search
-            target_id: ID to find
-
-        Returns:
-            Text content if found, None otherwise
-        """
-        if not hasattr(element, "__dict__"):
-            return None
-
-        # Check if this element has the target ID
-        if hasattr(element, "ID") and target_id == element.ID:
-            # Extract text content from this element
-            return self._extract_text_from_element(element)
-
-        # Recursively search child elements
-        for attr_value in vars(element).values():
-            if isinstance(attr_value, list):
-                for item in attr_value:
-                    text = self._search_element_for_id(item, target_id)
-                    if text:
-                        return text
-            elif hasattr(attr_value, "__dict__"):
-                text = self._search_element_for_id(attr_value, target_id)
-                if text:
-                    return text
-
-        return None
-
     def _extract_text_from_element(self, element) -> str:
         """Extract all text content from an element.
 

--- a/ccda_to_fhir/converters/patient.py
+++ b/ccda_to_fhir/converters/patient.py
@@ -198,28 +198,6 @@ class PatientConverter(BaseConverter[RecordTarget]):
 
         return generate_id_from_identifiers("Patient", root, extension)
 
-    def _generate_patient_id_OLD(self, identifier: II) -> str:
-        """Generate a patient resource ID from an identifier.
-
-        Args:
-            identifier: The C-CDA identifier
-
-        Returns:
-            A resource ID string
-        """
-        if identifier.extension:
-            # Use extension as basis for ID
-            return f"patient-{identifier.extension.lower().replace(' ', '-')}"
-        elif identifier.root:
-            # Use last 16 chars of root
-            root_suffix = identifier.root.replace(".", "").replace("-", "")[-16:]
-            return f"patient-{root_suffix}"
-        else:
-            raise ValueError(
-                "Cannot generate Patient ID: no identifiers provided. "
-                "C-CDA recordTarget/patientRole must have id element."
-            )
-
     def _extract_birth_date_and_time(self, birth_time) -> tuple[str | None, JSONObject | None]:
         """Extract birthDate and optionally patient-birthTime extension.
 


### PR DESCRIPTION
## Summary

- Remove `_generate_patient_id_OLD()` from patient.py (replaced by `generate_id_from_identifiers`)
- Remove `_extract_narrative_by_id()` and `_search_element_for_id()` from note_activity.py (unused, narrative extraction handled by struc_doc_utils)
- Remove `_format_name_for_display()` from immunization.py (duplicate of composition.py version, never called)
- Remove `_store_informant_metadata()` from convert.py (never called, informants handled inline)

**Total: 152 lines of dead code removed from 4 files**

## Test plan

- [x] All 2000 existing tests pass
- [x] No functional changes - only unused code removed
