### PR TITLE
Fix pyproject.toml metadata per current Python packaging standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ccda-to-fhir"
 version = "0.2.4"
 description = "A Python library to convert C-CDA documents to FHIR R4B resources"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 authors = [
     { name = "Nurra", email = "hello@nurra.ai" }
@@ -13,7 +13,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Healthcare Industry",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -39,10 +38,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/nurra/ccda-to-fhir"
-Documentation = "https://github.com/nurra/ccda-to-fhir#readme"
-Repository = "https://github.com/nurra/ccda-to-fhir.git"
-Issues = "https://github.com/nurra/ccda-to-fhir/issues"
+Homepage = "https://github.com/NurraHealth/ccda-to-fhir"
+Documentation = "https://github.com/NurraHealth/ccda-to-fhir#readme"
+Repository = "https://github.com/NurraHealth/ccda-to-fhir.git"
+Issues = "https://github.com/NurraHealth/ccda-to-fhir/issues"
 
 [build-system]
 requires = ["hatchling"]
@@ -102,7 +101,3 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.2",
-]


### PR DESCRIPTION
- Use SPDX license identifier directly (PEP 639)
- Remove deprecated License classifier
- Fix URLs to use correct organization (NurraHealth)
- Remove redundant [dependency-groups] section