### PR TITLE
Remove unused _generate_patient_id_OLD function

### DIFF
--- a/ccda_to_fhir/converters/patient.py
+++ b/ccda_to_fhir/converters/patient.py
@@ -200,28 +200,6 @@ class PatientConverter(BaseConverter[RecordTarget]):
 
         return generate_id_from_identifiers("Patient", root, extension)
 
-    def _generate_patient_id_OLD(self, identifier: II) -> str:
-        """Generate a patient resource ID from an identifier.
-
-        Args:
-            identifier: The C-CDA identifier
-
-        Returns:
-            A resource ID string
-        """
-        if identifier.extension:
-            # Use extension as basis for ID
-            return f"patient-{identifier.extension.lower().replace(' ', '-')}"
-        elif identifier.root:
-            # Use last 16 chars of root
-            root_suffix = identifier.root.replace(".", "").replace("-", "")[-16:]
-            return f"patient-{root_suffix}"
-        else:
-            raise ValueError(
-                "Cannot generate Patient ID: no identifiers provided. "
-                "C-CDA recordTarget/patientRole must have id element."
-            )
-
     def _extract_birth_date_and_time(self, birth_time) -> tuple[str | None, JSONObject | None]:
         """Extract birthDate and optionally patient-birthTime extension.
 


### PR DESCRIPTION
## Summary
- Remove dead code: `_generate_patient_id_OLD` function was not referenced anywhere