### PR TITLE
Update uv.lock version to 0.2.7

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "ccda-to-fhir"
-version = "0.2.5"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "fhir-resources" },


### PR DESCRIPTION
## Summary
- Sync uv.lock with version bump to 0.2.7

## Test plan
- [x] No code changes, lock file only