### PR TITLE
Add Coverage and ServiceRequest to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ print(f"Converted {len(bundle['entry'])} resources")
 | Encounters | Encounter |
 | Care Plans | CarePlan, Goal |
 | Care Teams | CareTeam |
+| Payers | Coverage, Organization |
+| Plan of Treatment | ServiceRequest |
 | Notes | DocumentReference |
 | Devices | Device |
 | Authors/Performers | Practitioner, PractitionerRole, Provenance |


### PR DESCRIPTION
## Summary
- Add Payers → Coverage, Organization to supported conversions table
- Add Plan of Treatment → ServiceRequest to supported conversions table

These were missing from the README after the Coverage converter (#20) was merged and ServiceRequest was already supported but undocumented.

## Test plan
- [x] README renders correctly