### PR TITLE
Ignore CareTeam no-participant errors during import

### DIFF
--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -189,7 +189,7 @@ def convert_careteam_organizer(
         return resources
     except ValueError as e:
         if "CareTeam requires at least one participant" in str(e):
-            logger.info("Skipping CareTeam with no participants: %s", e)
+            logger.info(f"Skipping CareTeam with no participants: {e}")
             return []
         logger.error("Error converting care team organizer", exc_info=True)
         raise

--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -187,6 +187,12 @@ def convert_careteam_organizer(
         resources.extend(converter.get_related_resources())
 
         return resources
+    except ValueError as e:
+        if "CareTeam requires at least one participant" in str(e):
+            logger.info("Skipping CareTeam with no participants: %s", e)
+            return []
+        logger.error("Error converting care team organizer", exc_info=True)
+        raise
     except Exception:
         logger.error("Error converting care team organizer", exc_info=True)
         raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ccda-to-fhir"
-version = "0.2.21"
+version = "0.2.22"
 description = "A Python library to convert C-CDA documents to FHIR R4B resources"
 readme = "README.md"
 license = "MIT"

--- a/tests/unit/converters/test_careteam.py
+++ b/tests/unit/converters/test_careteam.py
@@ -1532,3 +1532,55 @@ class TestCareTeamTypeSafety:
         )
         assert converter.code_system_mapper is mapper
         assert converter.reference_registry is registry
+
+
+# ============================================================================
+# convert_careteam_organizer — top-level function tests
+# ============================================================================
+
+
+class TestConvertCareTeamOrganizer:
+    """Tests for the convert_careteam_organizer top-level function."""
+
+    @pytest.fixture
+    def registry(self) -> "ReferenceRegistry":
+        from ccda_to_fhir.converters.references import ReferenceRegistry
+
+        reg = ReferenceRegistry()
+        reg.register_resource({"resourceType": "Patient", "id": "patient-123"})
+        return reg
+
+    @pytest.fixture
+    def organizer_no_participants(self) -> Organizer:
+        return Organizer(
+            class_code="CLUSTER",
+            mood_code="EVN",
+            template_id=[II(root="2.16.840.1.113883.10.20.22.4.500", extension="2022-06-01")],
+            id=[II(root="2.16.840.1.113883.19.5", extension="team-no-members")],
+            code=CE(code="86744-0", code_system="2.16.840.1.113883.6.1"),
+            status_code=CS(code="active"),
+            effective_time=IVL_TS(low=TS(value="20230115")),
+            component=[],
+        )
+
+    def test_no_participants_returns_empty_list(self, registry, organizer_no_participants) -> None:
+        """When the organizer has no participants, return [] instead of raising."""
+        from ccda_to_fhir.convert import convert_careteam_organizer
+
+        result = convert_careteam_organizer(
+            organizer_no_participants,
+            reference_registry=registry,
+        )
+        assert result == []
+
+    def test_no_participants_does_not_raise(self, registry, organizer_no_participants) -> None:
+        """The no-participant ValueError must be swallowed, not propagated."""
+        from ccda_to_fhir.convert import convert_careteam_organizer
+
+        try:
+            convert_careteam_organizer(
+                organizer_no_participants,
+                reference_registry=registry,
+            )
+        except ValueError:
+            pytest.fail("convert_careteam_organizer raised ValueError for missing participants")


### PR DESCRIPTION
## Summary
- When source data lacks participants, skip the CareTeam instead of propagating a `ValueError`
- Logs at `info` level rather than `error` so it doesn't surface as a failure during import

## Test plan
- [ ] Verify import completes without error when a CareTeam organizer has no participants
- [ ] Confirm info log message appears: "Skipping CareTeam with no participants"

🤖 Generated with [Claude Code](https://claude.com/claude-code)