### PR TITLE
Propagate C-CDA encounter context to clinical resources

### DIFF
--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -49,6 +49,7 @@ from ccda_to_fhir.types import (
     EncounterContext,
     FHIRResourceDict,
     JSONObject,
+    JSONValue,
     ValidationStats,
     format_human_name_display,
 )
@@ -137,6 +138,25 @@ RESOURCE_TYPE_MAPPING: dict[str, type[FHIRAbstractModel]] = {
     "Coverage": Coverage,
     "Appointment": Appointment,
 }
+
+DOCUMENT_ENCOUNTER_FIELD_RESOURCE_TYPES = frozenset(
+    {
+        "AllergyIntolerance",
+        "Condition",
+        "DiagnosticReport",
+        "Immunization",
+        "MedicationRequest",
+        "Observation",
+        "Procedure",
+        "ServiceRequest",
+    }
+)
+DOCUMENT_CONTEXT_FIELD_RESOURCE_TYPES = frozenset(
+    {
+        "MedicationDispense",
+        "MedicationStatement",
+    }
+)
 
 
 def convert_careteam_organizer(
@@ -503,6 +523,121 @@ class DocumentConverter:
             return self.validator.get_stats()
         return ValidationStats()
 
+    @staticmethod
+    def _reference_string(value: JSONValue | None) -> str | None:
+        """Extract a FHIR Reference.reference string from a serialized reference."""
+        if not isinstance(value, dict):
+            return None
+
+        reference = value.get("reference")
+        if isinstance(reference, str) and reference:
+            return reference
+        return None
+
+    @staticmethod
+    def _encounter_reference_candidates(resource: FHIRResourceDict) -> set[str]:
+        """Return reference strings that can address an Encounter resource in this bundle."""
+        if resource.get("resourceType") != "Encounter":
+            return set()
+
+        resource_id = resource.get("id")
+        if not isinstance(resource_id, str) or not resource_id:
+            return set()
+
+        return {f"urn:uuid:{resource_id}", f"Encounter/{resource_id}"}
+
+    def _valid_encounter_references(self, resources: list[FHIRResourceDict]) -> set[str]:
+        """Build the set of Encounter references backed by bundle resources."""
+        references: set[str] = set()
+        for resource in resources:
+            references.update(self._encounter_reference_candidates(resource))
+        return references
+
+    def _document_reference_has_valid_encounter(
+        self,
+        context: JSONObject,
+        valid_encounter_references: set[str],
+    ) -> bool:
+        """Check whether a DocumentReference context has a resolvable Encounter reference."""
+        encounter_values = context.get("encounter")
+        if not isinstance(encounter_values, list):
+            return False
+
+        for encounter_value in encounter_values:
+            reference = self._reference_string(encounter_value)
+            if reference and reference in valid_encounter_references:
+                return True
+        return False
+
+    @staticmethod
+    def _document_reference_encounter_display(context: JSONObject) -> str | None:
+        """Return the first existing DocumentReference encounter display, if present."""
+        encounter_values = context.get("encounter")
+        if not isinstance(encounter_values, list):
+            return None
+
+        for encounter_value in encounter_values:
+            if not isinstance(encounter_value, dict):
+                continue
+            display = encounter_value.get("display")
+            if isinstance(display, str) and display:
+                return display
+        return None
+
+    def _propagate_document_encounter_context(
+        self,
+        resources: list[FHIRResourceDict],
+        encounter_reference: str | None,
+    ) -> None:
+        """Attach document-level encounter context to clinical resources that lack it.
+
+        C-CDA ``componentOf/encompassingEncounter`` supplies the clinical encounter
+        context for the document. Entry resources often do not repeat that pointer,
+        so propagate the resolved document Encounter only where FHIR R4B has a
+        resource-specific encounter/context field and the resource has no explicit
+        encounter already.
+        """
+        if not encounter_reference:
+            return
+
+        valid_encounter_references = self._valid_encounter_references(resources)
+        valid_encounter_references.add(encounter_reference)
+
+        encounter_ref: JSONObject = {"reference": encounter_reference}
+
+        for resource in resources:
+            resource_type = resource.get("resourceType")
+            if not isinstance(resource_type, str):
+                continue
+
+            if resource_type in DOCUMENT_ENCOUNTER_FIELD_RESOURCE_TYPES:
+                if not self._reference_string(resource.get("encounter")):
+                    resource["encounter"] = encounter_ref.copy()
+                continue
+
+            if resource_type in DOCUMENT_CONTEXT_FIELD_RESOURCE_TYPES:
+                if not self._reference_string(resource.get("context")):
+                    resource["context"] = encounter_ref.copy()
+                continue
+
+            if resource_type == "DocumentReference":
+                context_value = resource.get("context")
+                context: JSONObject
+                if isinstance(context_value, dict):
+                    context = context_value
+                else:
+                    context = {}
+                    resource["context"] = context
+
+                if not self._document_reference_has_valid_encounter(
+                    context, valid_encounter_references
+                ):
+                    doc_ref_encounter = encounter_ref.copy()
+                    display = self._document_reference_encounter_display(context)
+                    if display:
+                        doc_ref_encounter["display"] = display
+                    context["encounter"] = [doc_ref_encounter]
+
     def convert(self, ccda_doc: ClinicalDocument) -> ConversionResult:
         """Convert a C-CDA document to a FHIR Bundle with metadata.
 
@@ -528,7 +663,8 @@ class DocumentConverter:
             "errors": [],
         }
 
-        resources = []
+        resources: list[FHIRResourceDict] = []
+        document_encounter_reference: str | None = None
         # Section→resource mapping for Composition.section[].entry references
         section_resource_map: dict[str, list[FHIRResourceDict]] = {}
 
@@ -926,6 +1062,9 @@ class DocumentConverter:
                     if self._encounters_are_duplicates(header_encounter, body_enc):
                         # Merge unique header data into body encounter
                         self._merge_header_into_body_encounter(header_encounter, body_enc)
+                        body_id = body_enc.get("id")
+                        if isinstance(body_id, str) and body_id:
+                            document_encounter_reference = f"urn:uuid:{body_id}"
                         duplicate_found = True
                         logger.debug(
                             f"Header encounter {header_id} merged into body encounter {body_enc.get('id')}"
@@ -935,6 +1074,8 @@ class DocumentConverter:
                 # Only add header encounter if it's not a duplicate
                 if not duplicate_found:
                     encounters.append(header_encounter)
+                    if isinstance(header_id, str) and header_id:
+                        document_encounter_reference = f"urn:uuid:{header_id}"
                     logger.debug(
                         f"Added header encounter {header_id} to bundle (no body duplicate)"
                     )
@@ -1102,6 +1243,8 @@ class DocumentConverter:
         resources.extend(related_persons)
         for related_person in related_persons:
             self.reference_registry.register_resource(related_person)
+
+        self._propagate_document_encounter_context(resources, document_encounter_reference)
 
         # Create Composition resource (required first entry in document bundle)
         composition_converter = CompositionConverter(
@@ -1647,7 +1790,9 @@ class DocumentConverter:
                                 if gender_identity_codeable:
                                     gender_identity_ext = {
                                         "url": FHIRSystems.US_CORE_GENDER_IDENTITY,
-                                        "valueCodeableConcept": gender_identity_codeable.model_dump(exclude_none=True),
+                                        "valueCodeableConcept": gender_identity_codeable.model_dump(
+                                            exclude_none=True
+                                        ),
                                     }
                                     extensions.append(gender_identity_ext)
                             processed = True
@@ -1688,7 +1833,9 @@ class DocumentConverter:
                                     spcu_ext["extension"].append(
                                         {
                                             "url": "value",
-                                            "valueCodeableConcept": value_concept.model_dump(exclude_none=True),
+                                            "valueCodeableConcept": value_concept.model_dump(
+                                                exclude_none=True
+                                            ),
                                         }
                                     )
 
@@ -1803,7 +1950,9 @@ class DocumentConverter:
                                         "extension": [
                                             {
                                                 "url": "tribalAffiliation",
-                                                "valueCodeableConcept": tribal_affiliation_codeable.model_dump(exclude_none=True),
+                                                "valueCodeableConcept": tribal_affiliation_codeable.model_dump(
+                                                    exclude_none=True
+                                                ),
                                             }
                                         ],
                                     }
@@ -1830,7 +1979,9 @@ class DocumentConverter:
                                             "extension": [
                                                 {
                                                     "url": "tribalAffiliation",
-                                                    "valueCodeableConcept": tribal_affiliation_codeable.model_dump(exclude_none=True),
+                                                    "valueCodeableConcept": tribal_affiliation_codeable.model_dump(
+                                                        exclude_none=True
+                                                    ),
                                                 }
                                             ],
                                         }
@@ -1865,7 +2016,9 @@ class DocumentConverter:
                                         spcu_ext["extension"].append(
                                             {
                                                 "url": "value",
-                                                "valueCodeableConcept": value_concept.model_dump(exclude_none=True),
+                                                "valueCodeableConcept": value_concept.model_dump(
+                                                    exclude_none=True
+                                                ),
                                             }
                                         )
 

--- a/tests/integration/test_encounter_display.py
+++ b/tests/integration/test_encounter_display.py
@@ -13,6 +13,11 @@ from ccda_to_fhir.convert import convert_document
 DOCUMENTS_DIR = Path(__file__).parent / "fixtures" / "documents"
 
 
+def _get_resources(bundle: dict) -> list[dict]:
+    """Extract Bundle resources."""
+    return [entry["resource"] for entry in bundle["entry"]]
+
+
 def _get_doc_refs(bundle: dict) -> list[dict]:
     """Extract all DocumentReference resources from a bundle."""
     return [
@@ -20,6 +25,26 @@ def _get_doc_refs(bundle: dict) -> list[dict]:
         for entry in bundle["entry"]
         if entry["resource"]["resourceType"] == "DocumentReference"
     ]
+
+
+def _first_encounter_reference(resources: list[dict]) -> str:
+    encounter = next(r for r in resources if r["resourceType"] == "Encounter")
+    return f"urn:uuid:{encounter['id']}"
+
+
+def _resource_encounter_reference(resource: dict) -> str | None:
+    encounter = resource.get("encounter")
+    if isinstance(encounter, dict):
+        reference = encounter.get("reference")
+        if isinstance(reference, str):
+            return reference
+
+    context = resource.get("context")
+    if isinstance(context, dict):
+        reference = context.get("reference")
+        if isinstance(reference, str):
+            return reference
+    return None
 
 
 class TestEncounterDisplayFromCode:
@@ -68,6 +93,41 @@ class TestEncounterDisplayFallback:
                     )
                     refs_with_display += 1
         assert refs_with_display >= 1, "Expected at least one encounter ref with fallback display"
+
+
+class TestDocumentEncounterContext:
+    """Regression tests for propagating componentOf/encompassingEncounter context."""
+
+    def test_athena_ccd_clinical_resources_share_resolved_document_encounter(self) -> None:
+        xml = (DOCUMENTS_DIR / "athena_ccd.xml").read_text()
+        result = convert_document(xml)
+        bundle = result["bundle"]
+        resources = _get_resources(bundle)
+        encounter_reference = _first_encounter_reference(resources)
+
+        for resource_type in (
+            "AllergyIntolerance",
+            "Condition",
+            "MedicationStatement",
+            "Observation",
+            "Procedure",
+            "ServiceRequest",
+        ):
+            matching_resources = [r for r in resources if r["resourceType"] == resource_type]
+            assert matching_resources, f"Expected {resource_type} resources in fixture"
+            assert {_resource_encounter_reference(resource) for resource in matching_resources} == {
+                encounter_reference
+            }
+
+        doc_refs = _get_doc_refs(bundle)
+        assert doc_refs, "Expected DocumentReference resources in fixture"
+        for doc_ref in doc_refs:
+            encounter_values = doc_ref["context"]["encounter"]
+            assert len(encounter_values) == 1
+            assert encounter_values[0]["reference"] == encounter_reference
+
+        composition = next(r for r in resources if r["resourceType"] == "Composition")
+        assert composition["encounter"] == {"reference": encounter_reference}
 
 
 class TestEncounterDisplayEndToEnd:

--- a/tests/unit/converters/test_careteam.py
+++ b/tests/unit/converters/test_careteam.py
@@ -22,6 +22,7 @@ from ccda_to_fhir.ccda.models.performer import (
 )
 from ccda_to_fhir.constants import FHIRCodes
 from ccda_to_fhir.converters.careteam import CareTeamConverter
+from ccda_to_fhir.converters.references import ReferenceRegistry
 
 
 @pytest.fixture
@@ -1543,9 +1544,7 @@ class TestConvertCareTeamOrganizer:
     """Tests for the convert_careteam_organizer top-level function."""
 
     @pytest.fixture
-    def registry(self) -> "ReferenceRegistry":
-        from ccda_to_fhir.converters.references import ReferenceRegistry
-
+    def registry(self) -> ReferenceRegistry:
         reg = ReferenceRegistry()
         reg.register_resource({"resourceType": "Patient", "id": "patient-123"})
         return reg

--- a/tests/unit/test_document_encounter_context.py
+++ b/tests/unit/test_document_encounter_context.py
@@ -1,0 +1,99 @@
+"""Tests for document-level encounter context propagation."""
+
+from ccda_to_fhir.convert import DocumentConverter
+from ccda_to_fhir.types import FHIRResourceDict
+
+
+def test_propagates_document_encounter_to_supported_clinical_resources() -> None:
+    converter = DocumentConverter()
+    resources: list[FHIRResourceDict] = [
+        {"resourceType": "Encounter", "id": "encounter-1"},
+        {"resourceType": "Condition", "id": "condition-1"},
+        {"resourceType": "Observation", "id": "observation-1"},
+        {"resourceType": "Procedure", "id": "procedure-1"},
+        {"resourceType": "ServiceRequest", "id": "service-request-1"},
+        {"resourceType": "MedicationRequest", "id": "medication-request-1"},
+        {"resourceType": "AllergyIntolerance", "id": "allergy-1"},
+        {"resourceType": "Immunization", "id": "immunization-1"},
+        {"resourceType": "DiagnosticReport", "id": "diagnostic-report-1"},
+        {"resourceType": "MedicationStatement", "id": "medication-statement-1"},
+        {"resourceType": "MedicationDispense", "id": "medication-dispense-1"},
+        {
+            "resourceType": "DocumentReference",
+            "id": "document-reference-1",
+            "context": {
+                "encounter": [
+                    {
+                        "reference": "urn:uuid:stale-header-encounter",
+                        "display": "Office visit",
+                    }
+                ]
+            },
+        },
+        {"resourceType": "Provenance", "id": "provenance-1"},
+    ]
+
+    converter._propagate_document_encounter_context(resources, "urn:uuid:encounter-1")
+
+    direct_encounter_types = {
+        "AllergyIntolerance",
+        "Condition",
+        "DiagnosticReport",
+        "Immunization",
+        "MedicationRequest",
+        "Observation",
+        "Procedure",
+        "ServiceRequest",
+    }
+    for resource in resources:
+        resource_type = resource["resourceType"]
+        if resource_type in direct_encounter_types:
+            assert resource["encounter"] == {"reference": "urn:uuid:encounter-1"}
+
+    context_types = {"MedicationDispense", "MedicationStatement"}
+    for resource in resources:
+        if resource["resourceType"] in context_types:
+            assert resource["context"] == {"reference": "urn:uuid:encounter-1"}
+
+    doc_ref = next(r for r in resources if r["resourceType"] == "DocumentReference")
+    assert doc_ref["context"] == {
+        "encounter": [{"reference": "urn:uuid:encounter-1", "display": "Office visit"}]
+    }
+
+    provenance = next(r for r in resources if r["resourceType"] == "Provenance")
+    assert "encounter" not in provenance
+    assert "context" not in provenance
+
+
+def test_preserves_existing_explicit_encounter_context() -> None:
+    converter = DocumentConverter()
+    resources: list[FHIRResourceDict] = [
+        {"resourceType": "Encounter", "id": "document-encounter"},
+        {"resourceType": "Encounter", "id": "explicit-encounter"},
+        {
+            "resourceType": "Condition",
+            "id": "condition-1",
+            "encounter": {"reference": "urn:uuid:explicit-encounter"},
+        },
+        {
+            "resourceType": "MedicationStatement",
+            "id": "medication-statement-1",
+            "context": {"reference": "urn:uuid:explicit-encounter"},
+        },
+        {
+            "resourceType": "DocumentReference",
+            "id": "document-reference-1",
+            "context": {"encounter": [{"reference": "urn:uuid:explicit-encounter"}]},
+        },
+    ]
+
+    converter._propagate_document_encounter_context(resources, "urn:uuid:document-encounter")
+
+    condition = next(r for r in resources if r["resourceType"] == "Condition")
+    assert condition["encounter"] == {"reference": "urn:uuid:explicit-encounter"}
+
+    medication = next(r for r in resources if r["resourceType"] == "MedicationStatement")
+    assert medication["context"] == {"reference": "urn:uuid:explicit-encounter"}
+
+    doc_ref = next(r for r in resources if r["resourceType"] == "DocumentReference")
+    assert doc_ref["context"] == {"encounter": [{"reference": "urn:uuid:explicit-encounter"}]}

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "ccda-to-fhir"
-version = "0.2.21"
+version = "0.2.22"
 source = { editable = "." }
 dependencies = [
     { name = "fhir-resources" },


### PR DESCRIPTION
## Why
C-CDA documents can carry document-level encounter context in `componentOf/encompassingEncounter`. The converter already created a FHIR Encounter from that context, but clinical entry resources were left disconnected when they did not repeat their own encounter pointer. Header/body encounter deduplication could also leave DocumentReference encounter refs pointing at the pre-merge header Encounter id.

## What
- Track the resolved document Encounter reference after header/body encounter merge.
- Propagate that Encounter to eligible FHIR R4B clinical resources that lack explicit encounter/context fields.
- Repair DocumentReference encounter refs when they do not resolve to an Encounter in the Bundle, while preserving existing display text.
- Preserve existing explicit encounter/context refs on clinical resources.
- Add unit coverage for propagation and integration coverage on an Athena C-CDA fixture.
- Sync `uv.lock` package version with `pyproject.toml` so hooks can run without lock churn.

## Testing
- `uv run pytest tests/unit/test_document_encounter_context.py tests/integration/test_encounter_display.py`
- `uv run pytest tests/unit/test_document_encounter_context.py tests/integration/test_encounter_display.py tests/unit/converters/test_careteam.py::TestConvertCareTeamOrganizer`
- `uv run pytest` (2777 passed, 403 warnings)
- `uv run ruff check --fix ccda_to_fhir/convert.py tests/integration/test_encounter_display.py tests/unit/test_document_encounter_context.py tests/unit/converters/test_careteam.py`
- `uv run pyright --level error`
- R4B smoke check: converted Athena C-CDA fixture validates with `fhir.resources.R4B.bundle.Bundle`.

## Notes
- Full `uv run ruff check --fix .` initially hit an existing hook issue in `tests/unit/converters/test_careteam.py`; this PR includes the minimal import/annotation cleanup needed for the pre-commit hook to pass.
- Full `uv run mypy ccda_to_fhir/` is not currently clean on main; it reports broad pre-existing typing errors unrelated to this change.