### PR TITLE
Constrain C-CDA document encounter propagation

### DIFF
--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -139,25 +139,6 @@ RESOURCE_TYPE_MAPPING: dict[str, type[FHIRAbstractModel]] = {
     "Appointment": Appointment,
 }
 
-DOCUMENT_ENCOUNTER_FIELD_RESOURCE_TYPES = frozenset(
-    {
-        "AllergyIntolerance",
-        "Condition",
-        "DiagnosticReport",
-        "Immunization",
-        "MedicationRequest",
-        "Observation",
-        "Procedure",
-        "ServiceRequest",
-    }
-)
-DOCUMENT_CONTEXT_FIELD_RESOURCE_TYPES = frozenset(
-    {
-        "MedicationDispense",
-        "MedicationStatement",
-    }
-)
-
 
 def convert_careteam_organizer(
     organizer: Organizer,
@@ -589,13 +570,17 @@ class DocumentConverter:
         resources: list[FHIRResourceDict],
         encounter_reference: str | None,
     ) -> None:
-        """Attach document-level encounter context to clinical resources that lack it.
+        """Attach document-level encounter context to document metadata.
 
         C-CDA ``componentOf/encompassingEncounter`` supplies the clinical encounter
-        context for the document. Entry resources often do not repeat that pointer,
-        so propagate the resolved document Encounter only where FHIR R4B has a
-        resource-specific encounter/context field and the resource has no explicit
-        encounter already.
+        context for the document. It is not a safe blanket encounter for every
+        entry in a longitudinal CCD: problem list items, historical procedures,
+        medication history, and old results can be documented in the encounter
+        note without having occurred during that encounter.
+
+        Keep this propagation scoped to DocumentReference metadata. Resource-level
+        FHIR encounter/context fields are populated only by explicit entry-level
+        relationships in the resource converters.
         """
         if not encounter_reference:
             return
@@ -608,16 +593,6 @@ class DocumentConverter:
         for resource in resources:
             resource_type = resource.get("resourceType")
             if not isinstance(resource_type, str):
-                continue
-
-            if resource_type in DOCUMENT_ENCOUNTER_FIELD_RESOURCE_TYPES:
-                if not self._reference_string(resource.get("encounter")):
-                    resource["encounter"] = encounter_ref.copy()
-                continue
-
-            if resource_type in DOCUMENT_CONTEXT_FIELD_RESOURCE_TYPES:
-                if not self._reference_string(resource.get("context")):
-                    resource["context"] = encounter_ref.copy()
                 continue
 
             if resource_type == "DocumentReference":

--- a/tests/integration/test_encounter_display.py
+++ b/tests/integration/test_encounter_display.py
@@ -96,9 +96,9 @@ class TestEncounterDisplayFallback:
 
 
 class TestDocumentEncounterContext:
-    """Regression tests for propagating componentOf/encompassingEncounter context."""
+    """Regression tests for componentOf/encompassingEncounter document context."""
 
-    def test_athena_ccd_clinical_resources_share_resolved_document_encounter(self) -> None:
+    def test_athena_ccd_does_not_assign_document_encounter_to_clinical_resources(self) -> None:
         xml = (DOCUMENTS_DIR / "athena_ccd.xml").read_text()
         result = convert_document(xml)
         bundle = result["bundle"]
@@ -115,9 +115,9 @@ class TestDocumentEncounterContext:
         ):
             matching_resources = [r for r in resources if r["resourceType"] == resource_type]
             assert matching_resources, f"Expected {resource_type} resources in fixture"
-            assert {_resource_encounter_reference(resource) for resource in matching_resources} == {
-                encounter_reference
-            }
+            assert encounter_reference not in {
+                _resource_encounter_reference(resource) for resource in matching_resources
+            }, f"{resource_type} should not inherit the document-level encounter"
 
         doc_refs = _get_doc_refs(bundle)
         assert doc_refs, "Expected DocumentReference resources in fixture"

--- a/tests/unit/test_document_encounter_context.py
+++ b/tests/unit/test_document_encounter_context.py
@@ -4,7 +4,7 @@ from ccda_to_fhir.convert import DocumentConverter
 from ccda_to_fhir.types import FHIRResourceDict
 
 
-def test_propagates_document_encounter_to_supported_clinical_resources() -> None:
+def test_propagates_document_encounter_only_to_document_references() -> None:
     converter = DocumentConverter()
     resources: list[FHIRResourceDict] = [
         {"resourceType": "Encounter", "id": "encounter-1"},
@@ -35,7 +35,7 @@ def test_propagates_document_encounter_to_supported_clinical_resources() -> None
 
     converter._propagate_document_encounter_context(resources, "urn:uuid:encounter-1")
 
-    direct_encounter_types = {
+    clinical_resource_types = {
         "AllergyIntolerance",
         "Condition",
         "DiagnosticReport",
@@ -46,14 +46,13 @@ def test_propagates_document_encounter_to_supported_clinical_resources() -> None
         "ServiceRequest",
     }
     for resource in resources:
-        resource_type = resource["resourceType"]
-        if resource_type in direct_encounter_types:
-            assert resource["encounter"] == {"reference": "urn:uuid:encounter-1"}
+        if resource["resourceType"] in clinical_resource_types:
+            assert "encounter" not in resource
 
     context_types = {"MedicationDispense", "MedicationStatement"}
     for resource in resources:
         if resource["resourceType"] in context_types:
-            assert resource["context"] == {"reference": "urn:uuid:encounter-1"}
+            assert "context" not in resource
 
     doc_ref = next(r for r in resources if r["resourceType"] == "DocumentReference")
     assert doc_ref["context"] == {
@@ -97,3 +96,44 @@ def test_preserves_existing_explicit_encounter_context() -> None:
 
     doc_ref = next(r for r in resources if r["resourceType"] == "DocumentReference")
     assert doc_ref["context"] == {"encounter": [{"reference": "urn:uuid:explicit-encounter"}]}
+
+
+def test_document_encounter_does_not_override_or_create_clinical_context() -> None:
+    converter = DocumentConverter()
+    resources: list[FHIRResourceDict] = [
+        {"resourceType": "Encounter", "id": "document-encounter"},
+        {
+            "resourceType": "Procedure",
+            "id": "historical-procedure",
+            "performedDateTime": "1977-08-26",
+        },
+        {
+            "resourceType": "Observation",
+            "id": "future-result",
+            "effectiveDateTime": "2026-08-15",
+        },
+        {
+            "resourceType": "Condition",
+            "id": "explicit-condition",
+            "encounter": {"reference": "urn:uuid:explicit-encounter"},
+        },
+        {
+            "resourceType": "MedicationStatement",
+            "id": "explicit-medication",
+            "context": {"reference": "urn:uuid:explicit-encounter"},
+        },
+    ]
+
+    converter._propagate_document_encounter_context(resources, "urn:uuid:document-encounter")
+
+    historical_procedure = next(r for r in resources if r["id"] == "historical-procedure")
+    assert "encounter" not in historical_procedure
+
+    future_result = next(r for r in resources if r["id"] == "future-result")
+    assert "encounter" not in future_result
+
+    explicit_condition = next(r for r in resources if r["id"] == "explicit-condition")
+    assert explicit_condition["encounter"] == {"reference": "urn:uuid:explicit-encounter"}
+
+    explicit_medication = next(r for r in resources if r["id"] == "explicit-medication")
+    assert explicit_medication["context"] == {"reference": "urn:uuid:explicit-encounter"}


### PR DESCRIPTION
## Why

C-CDA documents can carry document-level encounter context in `ClinicalDocument/componentOf/encompassingEncounter`. We were copying that document context onto clinical FHIR resources, which over-linked longitudinal CCD content such as historical procedures, results, medications, and conditions to one encounter.

## What

- Limit document-level encounter propagation to `DocumentReference.context.encounter`.
- Keep `Composition.encounter` behavior from the existing document conversion.
- Do not fabricate resource-level `encounter`/`context` references for clinical entries from document-level context alone.
- Preserve existing explicit resource-level encounter/context references when converters provide them.
- Update regression coverage for the Athena CCD/Nancy fixture shape.

## Testing

- `uv run pytest tests/unit/test_document_encounter_context.py tests/integration/test_encounter_display.py`
- `uv run ruff check --fix ccda_to_fhir/convert.py tests/integration/test_encounter_display.py tests/unit/test_document_encounter_context.py`
- `uv run ruff format ccda_to_fhir/convert.py tests/integration/test_encounter_display.py tests/unit/test_document_encounter_context.py`
- Nancy synthetic C-CDA structural probe: linked resources reduced to `Composition`, `DocumentReference`, and the `Encounter` itself.
- `uv run pytest`