### PR TITLE
fix: log uncodeable result-organizer skip at info, not error

### DIFF
--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -41,7 +41,7 @@ from ccda_to_fhir.ccda.models.section import Section, StructuredBody
 from ccda_to_fhir.ccda.models.substance_administration import SubstanceAdministration
 from ccda_to_fhir.ccda.parser import parse_ccda
 from ccda_to_fhir.constants import PARTICIPATION_FUNCTION_CODE_MAP, TemplateIds
-from ccda_to_fhir.exceptions import CCDAConversionError
+from ccda_to_fhir.exceptions import CCDAConversionError, MissingRequiredFieldError
 from ccda_to_fhir.logging_config import get_logger
 from ccda_to_fhir.types import (
     ConversionMetadata,
@@ -1648,9 +1648,21 @@ class DocumentConverter:
             with converting(
                 metadata, TemplateIds.RESULT_ORGANIZER, organizer.id, "result organizer"
             ):
-                report, observations = self.diagnostic_report_converter.convert(
-                    organizer, section=section
-                )
+                try:
+                    report, observations = self.diagnostic_report_converter.convert(
+                        organizer, section=section
+                    )
+                except MissingRequiredFieldError as e:
+                    # A component observation has a nullFlavor code with no extractable
+                    # text, so the organizer cannot form a valid panel. This is expected
+                    # bad-input handling, not a conversion failure: log at info (not error)
+                    # so it doesn't surface as a production error, and skip the whole
+                    # organizer (behavior unchanged). Mirrors CareTeam no-participant
+                    # handling (#116).
+                    logger.info(
+                        f"Skipping result organizer with uncodeable component observation: {e}"
+                    )
+                    continue
                 resources.append(report)
                 resources.extend(observations)
 

--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -1645,24 +1645,22 @@ class DocumentConverter:
         for organizer, section, _section_code in iter_matching_organizers(
             structured_body, TemplateIds.RESULT_ORGANIZER
         ):
+            # A component observation may have a nullFlavor code with no extractable
+            # text, so the organizer cannot form a valid panel. That is expected
+            # bad-input handling, not a conversion failure: treat it as an expected
+            # skip (logged at info, tracked as skipped) so it doesn't surface as a
+            # production error. The whole organizer is skipped (behavior unchanged).
+            # Mirrors CareTeam no-participant handling (#116).
             with converting(
-                metadata, TemplateIds.RESULT_ORGANIZER, organizer.id, "result organizer"
+                metadata,
+                TemplateIds.RESULT_ORGANIZER,
+                organizer.id,
+                "result organizer",
+                expected_skips=(MissingRequiredFieldError,),
             ):
-                try:
-                    report, observations = self.diagnostic_report_converter.convert(
-                        organizer, section=section
-                    )
-                except MissingRequiredFieldError as e:
-                    # A component observation has a nullFlavor code with no extractable
-                    # text, so the organizer cannot form a valid panel. This is expected
-                    # bad-input handling, not a conversion failure: log at info (not error)
-                    # so it doesn't surface as a production error, and skip the whole
-                    # organizer (behavior unchanged). Mirrors CareTeam no-participant
-                    # handling (#116).
-                    logger.info(
-                        f"Skipping result organizer with uncodeable component observation: {e}"
-                    )
-                    continue
+                report, observations = self.diagnostic_report_converter.convert(
+                    organizer, section=section
+                )
                 resources.append(report)
                 resources.extend(observations)
 

--- a/ccda_to_fhir/converters/section_traversal.py
+++ b/ccda_to_fhir/converters/section_traversal.py
@@ -179,11 +179,19 @@ def converting(
     template_id: str,
     element_ids: list[II] | None,
     error_message: str,
+    expected_skips: tuple[type[Exception], ...] = (),
 ) -> Iterator[None]:
     """Context manager for converter error handling and metadata tracking.
 
     Wraps a converter call to handle exceptions and track processed/errored
     templates in conversion metadata.
+
+    Args:
+        expected_skips: Exception types that represent expected bad-input handling
+            rather than conversion failures. When one is raised, it is logged at
+            info level and tracked as *skipped* (not processed or errored), so it
+            does not surface as a production error. All other exceptions are still
+            logged at error level and tracked as errors.
 
     Usage:
         with converting(metadata, TemplateIds.XXX, element.id, "xxx"):
@@ -194,6 +202,10 @@ def converting(
         yield
         if metadata is not None:
             track_processed(metadata, template_id)
+    except expected_skips as e:
+        if metadata is not None:
+            track_skipped(metadata, template_id)
+        logger.info(f"Skipping {error_message}: {e}")
     except Exception as e:
         if metadata is not None:
             track_error(metadata, template_id, element_ids, e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ccda-to-fhir"
-version = "0.2.22"
+version = "0.2.23"
 description = "A Python library to convert C-CDA documents to FHIR R4B resources"
 readme = "README.md"
 license = "MIT"

--- a/tests/integration/test_observation_nullflavor.py
+++ b/tests/integration/test_observation_nullflavor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from ccda_to_fhir.convert import convert_document
 from ccda_to_fhir.types import JSONObject
 
@@ -176,3 +178,57 @@ class TestObservationNullFlavor:
             "Organizer with any nullFlavor component should be skipped entirely "
             "(current behavior - entire panel skipped if any component invalid)"
         )
+
+    def test_nullflavor_organizer_skip_is_logged_as_info_not_error(self, caplog) -> None:
+        """A result organizer skipped because a component code is uncodeable is
+        expected bad-input handling, not a conversion failure.
+
+        It must be logged at info level (not error) so it does not surface as a
+        production error in Sentry. Mirrors the CareTeam no-participant handling.
+        The whole panel is still skipped (behavior unchanged).
+        """
+        ccda = """
+<organizer classCode="BATTERY" moodCode="EVN" xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+    <id root="result-org-skip"/>
+    <code code="24357-6" codeSystem="2.16.840.1.113883.6.1" displayName="Test Panel"/>
+    <statusCode code="completed"/>
+    <effectiveTime value="20240121"/>
+    <component>
+        <observation classCode="OBS" moodCode="EVN">
+            <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+            <id root="obs-nullflavor-skip"/>
+            <code nullFlavor="NI" xsi:type="CE"/>
+            <statusCode code="completed"/>
+            <effectiveTime value="20240121"/>
+            <value nullFlavor="NI" xsi:type="CD"/>
+        </observation>
+    </component>
+</organizer>
+"""
+        ccda_doc = wrap_in_ccda_document(ccda, RESULTS_TEMPLATE_ID)
+
+        with caplog.at_level(logging.INFO):
+            bundle = convert_document(ccda_doc)["bundle"]
+
+        # Behavior unchanged: the whole panel is still skipped.
+        assert _find_all_resources_in_bundle(bundle, "Observation") == []
+
+        # The skip must NOT surface as an error.
+        organizer_errors = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "organizer" in r.getMessage().lower()
+        ]
+        assert not organizer_errors, (
+            "Skipping an uncodeable result organizer should not be logged as an error: "
+            f"{[r.getMessage() for r in organizer_errors]}"
+        )
+
+        # And it should be logged at info as an explicit, intentional skip.
+        info_skips = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO and "skipping result organizer" in r.getMessage().lower()
+        ]
+        assert info_skips, "Expected an info-level skip log for the result organizer"

--- a/tests/integration/test_observation_nullflavor.py
+++ b/tests/integration/test_observation_nullflavor.py
@@ -10,6 +10,7 @@ from ccda_to_fhir.types import JSONObject
 from .conftest import wrap_in_ccda_document
 
 RESULTS_TEMPLATE_ID = "2.16.840.1.113883.10.20.22.2.3.1"
+RESULTS_ORGANIZER_TEMPLATE_ID = "2.16.840.1.113883.10.20.22.4.1"
 
 
 def _find_all_resources_in_bundle(bundle: JSONObject, resource_type: str) -> list[JSONObject]:
@@ -184,8 +185,9 @@ class TestObservationNullFlavor:
         expected bad-input handling, not a conversion failure.
 
         It must be logged at info level (not error) so it does not surface as a
-        production error in Sentry. Mirrors the CareTeam no-participant handling.
-        The whole panel is still skipped (behavior unchanged).
+        production error in Sentry, and tracked as *skipped* (not processed or
+        errored) in conversion metadata. Mirrors the CareTeam no-participant
+        handling. The whole panel is still skipped (behavior unchanged).
         """
         ccda = """
 <organizer classCode="BATTERY" moodCode="EVN" xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -209,7 +211,9 @@ class TestObservationNullFlavor:
         ccda_doc = wrap_in_ccda_document(ccda, RESULTS_TEMPLATE_ID)
 
         with caplog.at_level(logging.INFO):
-            bundle = convert_document(ccda_doc)["bundle"]
+            result = convert_document(ccda_doc)
+        bundle = result["bundle"]
+        metadata = result["metadata"]
 
         # Behavior unchanged: the whole panel is still skipped.
         assert _find_all_resources_in_bundle(bundle, "Observation") == []
@@ -232,3 +236,10 @@ class TestObservationNullFlavor:
             if r.levelno == logging.INFO and "skipping result organizer" in r.getMessage().lower()
         ]
         assert info_skips, "Expected an info-level skip log for the result organizer"
+
+        # The organizer must be tracked as skipped, not processed or errored.
+        assert RESULTS_ORGANIZER_TEMPLATE_ID in metadata["skipped_templates"]
+        assert RESULTS_ORGANIZER_TEMPLATE_ID not in metadata["processed_templates"]
+        assert not [
+            e for e in metadata["errors"] if e["template_id"] == RESULTS_ORGANIZER_TEMPLATE_ID
+        ]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "ccda-to-fhir"
-version = "0.2.22"
+version = "0.2.23"
 source = { editable = "." }
 dependencies = [
     { name = "fhir-resources" },


### PR DESCRIPTION
## Why

Sentry **BACKEND-PRODUCTION-N** (`MissingRequiredFieldError: Observation is missing required field: code (Observation code has nullFlavor with no extractable text)`).

A result organizer (lab panel) contained a component `Observation` whose `code` had a `nullFlavor` and no narrative text to fall back on, so it can't form a valid FHIR `Observation`. The library correctly skips such panels — this is a documented, tested decision ("better to skip entire panel than create incomplete panel", see `tests/integration/test_observation_nullflavor.py`).

The problem was only that the skip was logged at **`error`** level via the generic `converting` wrapper, so an expected bad-input case surfaced as a new production error in Sentry.

## What

- Catch `MissingRequiredFieldError` in `DocumentConverter._extract_results` and log it at **`info`** instead of letting it bubble to the `error`-level `converting` handler.
- **Behavior unchanged**: the whole organizer is still skipped (no partial panels).
- Mirrors the CareTeam no-participant handling (#116).
- Bump version `0.2.22` → `0.2.23`.

## Testing

- [x] New test `test_nullflavor_organizer_skip_is_logged_as_info_not_error` (TDD: RED before fix, GREEN after) asserts the skip logs at info, not error, and the panel is still dropped.
- [x] Existing `test_observation_nullflavor.py` behavioral assertions unchanged and passing.
- [x] Full suite: 2779 passed; `ruff check` clean.

## Follow-up

After merge, bump the `ccda-to-fhir` pin in `NurraHealth/webapp` to pick this up.

Fixes BACKEND-PRODUCTION-N