### PR TITLE
Handle duplicate Bundle entries

### DIFF
--- a/ccda_to_fhir/convert.py
+++ b/ccda_to_fhir/convert.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Literal
 
 from fhir.resources.R4B.allergyintolerance import AllergyIntolerance
 from fhir.resources.R4B.appointment import Appointment
@@ -107,6 +108,13 @@ from .converters.section_traversal import (
 from .converters.service_request import ServiceRequestConverter
 
 logger = get_logger(__name__)
+
+DuplicateBundleEntryPolicy = Literal["skip", "fail"]
+
+
+class DuplicateBundleEntryError(CCDAConversionError):
+    """Raised when duplicate Bundle entries are encountered in strict mode."""
+
 
 # Mapping of FHIR resource types to their fhir.resources classes for validation
 RESOURCE_TYPE_MAPPING: dict[str, type[FHIRAbstractModel]] = {
@@ -271,6 +279,7 @@ class DocumentConverter:
         code_system_mapper: CodeSystemMapper | None = None,
         enable_validation: bool = False,
         strict_validation: bool = False,
+        duplicate_bundle_entry_policy: DuplicateBundleEntryPolicy = "skip",
     ):
         """Initialize the document converter.
 
@@ -278,8 +287,14 @@ class DocumentConverter:
             code_system_mapper: Optional code system mapper
             enable_validation: If True, validate FHIR resources during conversion
             strict_validation: If True, raise exceptions on validation failures
+            duplicate_bundle_entry_policy: How to handle duplicate Bundle fullUrl/versionId keys.
+                "skip" keeps the first entry and logs a warning; "fail" raises an error.
         """
+        if duplicate_bundle_entry_policy not in ("skip", "fail"):
+            raise ValueError("duplicate_bundle_entry_policy must be 'skip' or 'fail'")
+
         self.code_system_mapper = code_system_mapper or CodeSystemMapper()
+        self.duplicate_bundle_entry_policy = duplicate_bundle_entry_policy
 
         # Reference registry for tracking and validating resource references
         self.reference_registry = ReferenceRegistry()
@@ -1358,8 +1373,12 @@ class DocumentConverter:
             if timestamp:
                 bundle["timestamp"] = timestamp
 
-        # Add resources as bundle entries (Composition first, then all others)
-        for resource in resources:
+        # Add resources as bundle entries (Composition first, then all others).
+        # C-CDA documents can repeat the same source act in multiple sections. Stable
+        # ID generation correctly maps those repeats to the same FHIR id; enforce
+        # the Bundle fullUrl/versionId uniqueness invariant here before returning.
+        seen_bundle_keys: dict[tuple[str, str | None], tuple[int, str | None]] = {}
+        for resource_index, resource in enumerate(resources):
             entry: JSONObject = {
                 "resource": resource,
             }
@@ -1367,6 +1386,34 @@ class DocumentConverter:
                 resource["resourceType"]
                 resource_id = resource["id"]
                 entry["fullUrl"] = f"urn:uuid:{resource_id}"
+
+                meta = resource.get("meta", {})
+                version_id = meta.get("versionId") if isinstance(meta, dict) else None
+                bundle_key = (entry["fullUrl"], version_id)
+                if bundle_key in seen_bundle_keys:
+                    kept_index, kept_resource_type = seen_bundle_keys[bundle_key]
+                    message = (
+                        "Duplicate Bundle entry encountered: "
+                        f"resourceType={resource.get('resourceType')}, "
+                        f"fullUrl={entry['fullUrl']}, "
+                        f"versionId={version_id}, "
+                        f"kept_index={kept_index}, "
+                        f"duplicate_index={resource_index}"
+                    )
+                    if self.duplicate_bundle_entry_policy == "fail":
+                        raise DuplicateBundleEntryError(message)
+                    logger.warning(
+                        "Skipping duplicate Bundle entry",
+                        resource_type=resource.get("resourceType"),
+                        full_url=entry["fullUrl"],
+                        version_id=version_id,
+                        kept_index=kept_index,
+                        kept_resource_type=kept_resource_type,
+                        duplicate_index=resource_index,
+                    )
+                    continue
+
+                seen_bundle_keys[bundle_key] = (resource_index, resource.get("resourceType"))
             bundle["entry"].append(entry)
 
         # Log validation statistics
@@ -4099,7 +4146,11 @@ class DocumentConverter:
         return (practitioners, related_persons)
 
 
-def convert_document(ccda_input: str | ClinicalDocument) -> ConversionResult:
+def convert_document(
+    ccda_input: str | ClinicalDocument,
+    *,
+    duplicate_bundle_entry_policy: DuplicateBundleEntryPolicy = "skip",
+) -> ConversionResult:
     """Main conversion entry point.
 
     This is a convenience function that handles both XML strings and
@@ -4107,6 +4158,8 @@ def convert_document(ccda_input: str | ClinicalDocument) -> ConversionResult:
 
     Args:
         ccda_input: Either an XML string or a parsed ClinicalDocument
+        duplicate_bundle_entry_policy: How to handle duplicate Bundle fullUrl/versionId keys.
+            "skip" keeps the first entry and logs a warning; "fail" raises an error.
 
     Returns:
         ConversionResult with bundle and metadata about processing
@@ -4118,5 +4171,5 @@ def convert_document(ccda_input: str | ClinicalDocument) -> ConversionResult:
     ccda_doc = parse_ccda(ccda_input) if isinstance(ccda_input, str) else ccda_input
 
     # Convert using DocumentConverter
-    converter = DocumentConverter()
+    converter = DocumentConverter(duplicate_bundle_entry_policy=duplicate_bundle_entry_policy)
     return converter.convert(ccda_doc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ccda-to-fhir"
-version = "0.2.22"
+version = "0.2.23"
 description = "A Python library to convert C-CDA documents to FHIR R4B resources"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ccda-to-fhir"
-version = "0.2.23"
+version = "0.3"
 description = "A Python library to convert C-CDA documents to FHIR R4B resources"
 readme = "README.md"
 license = "MIT"

--- a/tests/integration/test_referral_simple.py
+++ b/tests/integration/test_referral_simple.py
@@ -6,7 +6,9 @@ resources with referral category.
 
 from __future__ import annotations
 
-from ccda_to_fhir.convert import convert_document
+import pytest
+
+from ccda_to_fhir.convert import DuplicateBundleEntryError, convert_document
 
 # ============================================================================
 # Test C-CDA Documents
@@ -256,6 +258,49 @@ def _find_resources(bundle: dict, resource_type: str) -> list[dict]:
     ]
 
 
+def _with_duplicate_patient_referral_act(ccda_xml: str) -> str:
+    duplicate_section = """
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <code code="42349-1" codeSystem="2.16.840.1.113883.6.1" displayName="Reason for Referral"/>
+                    <title>Reason for Referral</title>
+                    <text>Referral to cardiology.</text>
+                    <entry>
+                        <act classCode="PCPR" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.140"/>
+                            <id root="referral-id-001"/>
+                            <code code="3457005" codeSystem="2.16.840.1.113883.6.96"
+                                  displayName="Patient referral"/>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20240701"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+"""
+    return ccda_xml.replace("</structuredBody>", f"{duplicate_section}</structuredBody>")
+
+
+def _bundle_duplicate_keys(bundle: dict) -> list[tuple[str, str | None]]:
+    seen: set[tuple[str, str | None]] = set()
+    duplicates: list[tuple[str, str | None]] = []
+    for entry in bundle.get("entry", []):
+        full_url = entry.get("fullUrl")
+        resource = entry.get("resource", {})
+        meta = resource.get("meta", {})
+        version_id = meta.get("versionId") if isinstance(meta, dict) else None
+        if not full_url:
+            continue
+        key = (full_url, version_id)
+        if key in seen:
+            duplicates.append(key)
+        seen.add(key)
+    return duplicates
+
+
 class TestBasicReferral:
     """Test basic referral conversion end-to-end."""
 
@@ -308,6 +353,24 @@ class TestBasicReferral:
         assert len(referral_srs) >= 1
         sr = referral_srs[0]
         assert "us-core-servicerequest" in sr["meta"]["profile"][0]
+
+    def test_duplicate_bundle_entry_policy_skip_keeps_first_service_request(self, caplog):
+        """Default duplicate policy skips repeated Bundle keys and returns a valid Bundle."""
+        result = convert_document(_with_duplicate_patient_referral_act(CCDA_BASIC_REFERRAL))
+        bundle = result["bundle"]
+        service_requests = _find_resources(bundle, "ServiceRequest")
+
+        assert len(service_requests) == 1
+        assert _bundle_duplicate_keys(bundle) == []
+        assert any("Skipping duplicate Bundle entry" in record.message for record in caplog.records)
+
+    def test_duplicate_bundle_entry_policy_fail_raises(self):
+        """Strict duplicate policy raises when repeated Bundle keys are encountered."""
+        with pytest.raises(DuplicateBundleEntryError, match="Duplicate Bundle entry encountered"):
+            convert_document(
+                _with_duplicate_patient_referral_act(CCDA_BASIC_REFERRAL),
+                duplicate_bundle_entry_policy="fail",
+            )
 
     def test_referral_status_active(self):
         """active → active."""


### PR DESCRIPTION
## Why
Some C-CDA documents repeat the same source act in multiple sections. Stable ID generation maps those repeated identifiers to the same FHIR id, which can produce duplicate Bundle `fullUrl` keys.

## What
- Add duplicate Bundle entry handling during final Bundle assembly.
- Default to `skip`, where the first entry wins and later duplicates are skipped with a warning.
- Add strict `fail` behavior through `duplicate_bundle_entry_policy="fail"`, raising `DuplicateBundleEntryError`.
- Add regression tests for both skip and fail behavior using a synthetic duplicate referral fixture.

## Testing
- `uv run pytest tests/integration/test_athena_ccd.py tests/integration/test_referral_simple.py -q`
- `uv run ruff check ccda_to_fhir/convert.py tests/integration/test_referral_simple.py`
- `uv run ruff format --check ccda_to_fhir/convert.py tests/integration/test_referral_simple.py`